### PR TITLE
feat: verify email on page load

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -9,7 +9,7 @@ import i18n from '../../utils/languages/i18n';
 
 import { useDispatch } from 'react-redux';
 import { useEffect, useState } from 'react';
-import { current } from 'redux/auth/authOperations';
+import { current, verifyEmail } from 'redux/auth/authOperations';
 import { setTokens, statusIsRegister } from 'redux/auth/authSlice';
 import useIsReloading from 'shared/hooks/useIsReloading';
 
@@ -37,6 +37,14 @@ const App = () => {
   );
 
   useEffect(() => {
+    const verificationToken = searchParams.get('verificationToken');
+    const otp = searchParams.get('otp');
+    if (verificationToken && otp) {
+      dispatch(verifyEmail({ verificationToken, otp }));
+      searchParams.delete('verificationTokne');
+      searchParams.delete('otp');
+    }
+
     const accessToken = searchParams.get('accessToken');
     const refreshToken = searchParams.get('refreshToken');
     const newUser = searchParams.get('newUser');

--- a/src/redux/auth/authOperations.js
+++ b/src/redux/auth/authOperations.js
@@ -120,3 +120,15 @@ export const updateAvatar = createAsyncThunk(
     },
   }
 );
+
+export const verifyEmail = createAsyncThunk(
+  'auth/verify',
+  async (data, { rejectWithValue }) => {
+    try {
+      const result = await api.verifyEmail(data);
+      return result.data;
+    } catch ({ message }) {
+      return rejectWithValue(message);
+    }
+  }
+);

--- a/src/redux/auth/authSlice.js
+++ b/src/redux/auth/authSlice.js
@@ -8,6 +8,7 @@ import {
   current,
   update,
   updateAvatar,
+  verifyEmail,
 } from './authOperations';
 
 const initialState = {
@@ -18,6 +19,7 @@ const initialState = {
   isRefreshing: false,
   error: null,
   isRegister: false,
+  verified: false,
 };
 
 const handlePending = store => {
@@ -97,7 +99,12 @@ const authSlice = createSlice({
         store.isRefreshing = false;
         store.user.avatarUrl = payload.avatarUrl;
       })
-      .addCase(updateAvatar.rejected, handleRejected);
+      .addCase(updateAvatar.rejected, handleRejected)
+      .addCase(verifyEmail.pending, handlePending)
+      .addCase(verifyEmail.fulfilled, (store, { payload }) => {
+        store.verified = payload.verified;
+      })
+      .addCase(verifyEmail.rejected, handleRejected);
   },
 });
 

--- a/src/utils/Api.js
+++ b/src/utils/Api.js
@@ -240,4 +240,18 @@ export const updateUserInfo = async (token, data) => {
   }
 };
 
+export const verifyEmail = async data => {
+  try {
+    const response = await instance.post('api/users/verify', data);
+    return response;
+  } catch (error) {
+    const responseMessage = error.response?.data?.message;
+    const errorMessage = error.message;
+
+    throw new Error(
+      responseMessage || errorMessage || 'Failed to verify user email'
+    );
+  }
+};
+
 export default instance;


### PR DESCRIPTION
Добавил в redux операцию verifyEmail.
Если в searchPrams есть verificationToken и otp, отправляет запрос на верификацию почты.
Потенциальная проблема: почта успешно верифицирована, но в users/current пришло старое значение. Причина: запрос на получение информации о пользователе отправляется без ожидания завершения запроса на верификацию почты. 